### PR TITLE
Upgrade to Remix Auth v4 and react-router v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,51 +1,35 @@
 {
 	"name": "remix-auth-openid",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "remix-auth-openid",
-			"version": "0.2.1",
+			"version": "0.2.2",
 			"license": "MIT",
 			"dependencies": {
-				"openid-client": "^5.6.5"
+				"@mjackson/headers": "^0.9.0",
+				"openid-client": "^5.0.0",
+				"react-router": "^7.0.0"
 			},
 			"devDependencies": {
 				"@arethetypeswrong/cli": "^0.15.3",
 				"@biomejs/biome": "^1.7.2",
-				"@remix-run/node": "^2.8.1",
-				"@remix-run/server-runtime": "^2.8.1",
+				"@react-router/node": "^7.0.0",
 				"@types/bun": "^1.0.12",
 				"@types/debug": "^4.1.12",
 				"@types/jsonwebtoken": "^9.0.6",
 				"consola": "^3.2.3",
 				"jsonwebtoken": "^9.0.2",
 				"msw": "^2.2.13",
-				"remix-auth": "^3.6.0",
+				"remix-auth": "^4.1.0",
 				"typedoc": "^0.25.13",
 				"typedoc-plugin-mdn-links": "^3.1.25",
 				"typescript": "^5.4.5"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=20.0.0"
-			},
-			"peerDependencies": {
-				"@remix-run/cloudflare": "^1.0.0 || ^2.0.0",
-				"@remix-run/deno": "^1.0.0 || ^2.0.0",
-				"@remix-run/node": "^1.0.0 || ^2.0.0",
-				"remix-auth": "^3.6.0"
-			},
-			"peerDependenciesMeta": {
-				"@remix-run/cloudflare": {
-					"optional": true
-				},
-				"@remix-run/deno": {
-					"optional": true
-				},
-				"@remix-run/node": {
-					"optional": true
-				}
+				"node": "^20.0.0"
 			}
 		},
 		"node_modules/@andrewbranch/untar.js": {
@@ -273,19 +257,19 @@
 			}
 		},
 		"node_modules/@bundled-es-modules/cookie": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
-			"integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+			"integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"cookie": "^0.5.0"
+				"cookie": "^0.7.2"
 			}
 		},
 		"node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -400,6 +384,19 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@mjackson/headers": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@mjackson/headers/-/headers-0.9.0.tgz",
+			"integrity": "sha512-1WFCu2iRaqbez9hcYYI611vcH1V25R+fDfOge/CyKc8sdbzniGfy/FRhNd3DgvFF4ZEEX2ayBrvFHLtOpfvadw==",
+			"license": "MIT"
+		},
+		"node_modules/@mjackson/node-fetch-server": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
+			"integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@mswjs/cookies": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
@@ -453,149 +450,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@remix-run/node": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.2.tgz",
-			"integrity": "sha512-2Mt2107pfelz4T+ziDBef3P4A7kgPqCDshnEYCVGxInivJ3HHwAKUcb7MhGa8uMMMA6LMWxbAPYNHPzC3iKv2A==",
+		"node_modules/@react-router/node": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.1.1.tgz",
+			"integrity": "sha512-5X79SfJ1IEEsttt0oo9rhO9kgxXyBTKdVBsz3h0WHTkRzbRk0VEpVpBW3PQ1RpkgEaAHwJ8obVl4k4brdDSExA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@remix-run/server-runtime": "2.9.2",
-				"@remix-run/web-fetch": "^4.4.2",
-				"@web3-storage/multipart-parser": "^1.0.0",
-				"cookie-signature": "^1.1.0",
+				"@mjackson/node-fetch-server": "^0.2.0",
 				"source-map-support": "^0.5.21",
 				"stream-slice": "^0.1.2",
-				"undici": "^6.10.1"
+				"undici": "^6.19.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
+				"react-router": "7.1.1",
 				"typescript": "^5.1.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@remix-run/react": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.9.2.tgz",
-			"integrity": "sha512-DcZDzm68MBxGn8hjf/VsuUpjxDYZ8VOOH79P1zWu4hb3hBr90WV1Sa/gIAFUEGpOCcSQ0EG/ci8MaFxcAaPz2Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@remix-run/router": "1.16.1",
-				"@remix-run/server-runtime": "2.9.2",
-				"react-router": "6.23.1",
-				"react-router-dom": "6.23.1",
-				"turbo-stream": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0",
-				"typescript": "^5.1.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@remix-run/router": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
-			"integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@remix-run/server-runtime": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.9.2.tgz",
-			"integrity": "sha512-dX37FEeMVVg7KUbpRhX4hD0nUY0Sscz/qAjU4lYCdd6IzwJGariTmz+bQTXKCjploZuXj09OQZHSOS/ydkUVDA==",
-			"dev": true,
-			"dependencies": {
-				"@remix-run/router": "1.16.1",
-				"@types/cookie": "^0.6.0",
-				"@web3-storage/multipart-parser": "^1.0.0",
-				"cookie": "^0.6.0",
-				"set-cookie-parser": "^2.4.8",
-				"source-map": "^0.7.3",
-				"turbo-stream": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"typescript": "^5.1.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@remix-run/web-blob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.1.0.tgz",
-			"integrity": "sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==",
-			"dev": true,
-			"dependencies": {
-				"@remix-run/web-stream": "^1.1.0",
-				"web-encoding": "1.1.5"
-			}
-		},
-		"node_modules/@remix-run/web-fetch": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.4.2.tgz",
-			"integrity": "sha512-jgKfzA713/4kAW/oZ4bC3MoLWyjModOVDjFPNseVqcJKSafgIscrYL9G50SurEYLswPuoU3HzSbO0jQCMYWHhA==",
-			"dev": true,
-			"dependencies": {
-				"@remix-run/web-blob": "^3.1.0",
-				"@remix-run/web-file": "^3.1.0",
-				"@remix-run/web-form-data": "^3.1.0",
-				"@remix-run/web-stream": "^1.1.0",
-				"@web3-storage/multipart-parser": "^1.0.0",
-				"abort-controller": "^3.0.0",
-				"data-uri-to-buffer": "^3.0.1",
-				"mrmime": "^1.0.0"
-			},
-			"engines": {
-				"node": "^10.17 || >=12.3"
-			}
-		},
-		"node_modules/@remix-run/web-file": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.1.0.tgz",
-			"integrity": "sha512-dW2MNGwoiEYhlspOAXFBasmLeYshyAyhIdrlXBi06Duex5tDr3ut2LFKVj7tyHLmn8nnNwFf1BjNbkQpygC2aQ==",
-			"dev": true,
-			"dependencies": {
-				"@remix-run/web-blob": "^3.1.0"
-			}
-		},
-		"node_modules/@remix-run/web-form-data": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.1.0.tgz",
-			"integrity": "sha512-NdeohLMdrb+pHxMQ/Geuzdp0eqPbea+Ieo8M8Jx2lGC6TBHsgHzYcBvr0LyPdPVycNRDEpWpiDdCOdCryo3f9A==",
-			"dev": true,
-			"dependencies": {
-				"web-encoding": "1.1.5"
-			}
-		},
-		"node_modules/@remix-run/web-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.1.0.tgz",
-			"integrity": "sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==",
-			"dev": true,
-			"dependencies": {
-				"web-streams-polyfill": "^3.1.1"
 			}
 		},
 		"node_modules/@sindresorhus/is": {
@@ -624,8 +501,7 @@
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-			"dev": true
+			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
 		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
@@ -697,31 +573,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@web3-storage/multipart-parser": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
-			"integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
-			"dev": true
-		},
-		"node_modules/@zxing/text-encoding": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-			"integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-			"dev": true,
-			"optional": true
-		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
-			}
-		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -774,21 +625,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-			"dev": true,
-			"dependencies": {
-				"possible-typed-array-names": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -836,25 +672,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/call-bind": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-			"dev": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.4",
-				"set-function-length": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/cardinal": {
@@ -987,50 +804,6 @@
 				"node": "^14.18.0 || >=16.10.0"
 			}
 		},
-		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-signature": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.1.tgz",
-			"integrity": "sha512-78KWk9T26NhzXtuL26cIJ8/qNHANyJ/ZYrmEXFzUmhZdjpBv+DlWlOANRTGBt48YcyslsLrj0bMLFTmXvLRCOw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.6.0"
-			}
-		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/define-data-property": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"dev": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1054,27 +827,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-			"dev": true,
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/escalade": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -1097,39 +849,12 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/fflate": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
 			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
-			"dependencies": {
-				"is-callable": "^1.1.3"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -1138,37 +863,6 @@
 			"dev": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-			"dev": true,
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dev": true,
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/graphql": {
@@ -1190,109 +884,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/has-property-descriptors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"dev": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-proto": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/headers-polyfill": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
 			"integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
@@ -1303,21 +900,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-generator-function": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-node-process": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
@@ -1325,36 +907,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
-			"dev": true,
-			"dependencies": {
-				"which-typed-array": "^1.1.14"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/jose": {
-			"version": "4.15.5",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-			"integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+			"version": "4.15.9",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+			"integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
 			}
-		},
-		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.1",
@@ -1457,19 +1017,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
-			}
-		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1561,15 +1108,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/mrmime": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-			"integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/ms": {
@@ -1680,12 +1218,12 @@
 			}
 		},
 		"node_modules/openid-client": {
-			"version": "5.6.5",
-			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.5.tgz",
-			"integrity": "sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+			"integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
 			"license": "MIT",
 			"dependencies": {
-				"jose": "^4.15.5",
+				"jose": "^4.15.9",
 				"lru-cache": "^6.0.0",
 				"object-hash": "^2.2.0",
 				"oidc-token-hash": "^5.0.3"
@@ -1702,80 +1240,53 @@
 			"license": "MIT"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/possible-typed-array-names": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/react": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"dev": true,
+			"version": "19.0.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+			"integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+			"license": "MIT",
 			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/react-dom": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.2"
-			},
-			"peerDependencies": {
-				"react": "^18.3.1"
-			}
-		},
 		"node_modules/react-router": {
-			"version": "6.23.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
-			"integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
-			"dev": true,
-			"peer": true,
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.1.tgz",
+			"integrity": "sha512-39sXJkftkKWRZ2oJtHhCxmoCrBCULr/HAH4IT5DHlgu/Q0FCPV0S4Lx+abjDTx/74xoZzNYDYbOZWlJjruyuDQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@remix-run/router": "1.16.1"
+				"@types/cookie": "^0.6.0",
+				"cookie": "^1.0.1",
+				"set-cookie-parser": "^2.6.0",
+				"turbo-stream": "2.4.0"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"react": ">=16.8"
+				"react": ">=18",
+				"react-dom": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/react-router-dom": {
-			"version": "6.23.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
-			"integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@remix-run/router": "1.16.1",
-				"react-router": "6.23.1"
-			},
+		"node_modules/react-router/node_modules/cookie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.8",
-				"react-dom": ">=16.8"
+				"node": ">=18"
 			}
 		},
 		"node_modules/redeyed": {
@@ -1789,16 +1300,16 @@
 			}
 		},
 		"node_modules/remix-auth": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/remix-auth/-/remix-auth-3.7.0.tgz",
-			"integrity": "sha512-2QVjp2nJVaYxuFBecMQwzixCO7CLSssttLBU5eVlNcNlVeNMmY1g7OkmZ1Ogw9sBcoMXZ18J7xXSK0AISVFcfQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/remix-auth/-/remix-auth-4.1.0.tgz",
+			"integrity": "sha512-Xdy42clt+g79GCn+Wl1+B6S/yWnvrStnk62vo1pGuRuUwHC+pjmeEE52ZRkRPuhLGqsQnoDD9TVz/wfEJAGF8g==",
 			"dev": true,
-			"dependencies": {
-				"uuid": "^8.3.2"
-			},
-			"peerDependencies": {
-				"@remix-run/react": "^1.0.0 || ^2.0.0",
-				"@remix-run/server-runtime": "^1.0.0 || ^2.0.0"
+			"funding": [
+				"https://github.com/sponsors/sergiodxa"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/require-directory": {
@@ -1831,16 +1342,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/scheduler": {
-			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			}
-		},
 		"node_modules/semver": {
 			"version": "7.6.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -1857,25 +1358,7 @@
 		"node_modules/set-cookie-parser": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
-			"dev": true
-		},
-		"node_modules/set-function-length": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-			"dev": true,
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.4",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
+			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
 		},
 		"node_modules/shiki": {
 			"version": "0.14.7",
@@ -1900,15 +1383,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/source-map-support": {
@@ -2013,10 +1487,10 @@
 			"license": "MIT"
 		},
 		"node_modules/turbo-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.2.0.tgz",
-			"integrity": "sha512-FKFg7A0To1VU4CH9YmSMON5QphK0BXjSoiC7D9yMh+mEEbXLUP9qJ4hEt1qcjKtzncs1OpcnjZO8NgrlVbZH+g==",
-			"dev": true
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+			"integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+			"license": "ISC"
 		},
 		"node_modules/type-fest": {
 			"version": "0.21.3",
@@ -2087,10 +1561,11 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.18.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
-			"integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+			"integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
 			}
@@ -2109,28 +1584,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/validate-npm-package-name": {
@@ -2154,46 +1607,6 @@
 			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
 			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
 			"dev": true
-		},
-		"node_modules/web-encoding": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-			"integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-			"dev": true,
-			"dependencies": {
-				"util": "^0.12.3"
-			},
-			"optionalDependencies": {
-				"@zxing/text-encoding": "0.9.0"
-			}
-		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
-			"dev": true,
-			"dependencies": {
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
 		"openid-client": "^5.0.0",
 		"react-router": "^7.0.0"
 	},
+	"peerDependencies": {
+		"remix-auth": "^4.0.0"
+	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.15.3",
 		"@biomejs/biome": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"sideEffects": false,
 	"type": "module",
 	"engines": {
-		"node": "^18.0.0 || ^20.0.0 || >=20.0.0"
+		"node": "^20.0.0"
 	},
 	"files": [
 		"build",
@@ -46,37 +46,21 @@
 		"./package.json": "./package.json"
 	},
 	"dependencies": {
-		"openid-client": "^5.6.5"
-	},
-	"peerDependencies": {
-		"@remix-run/cloudflare": "^1.0.0 || ^2.0.0",
-		"@remix-run/deno": "^1.0.0 || ^2.0.0",
-		"@remix-run/node": "^1.0.0 || ^2.0.0",
-		"remix-auth": "^3.6.0"
-	},
-	"peerDependenciesMeta": {
-		"@remix-run/cloudflare": {
-			"optional": true
-		},
-		"@remix-run/node": {
-			"optional": true
-		},
-		"@remix-run/deno": {
-			"optional": true
-		}
+		"@mjackson/headers": "^0.9.0",
+		"openid-client": "^5.0.0",
+		"react-router": "^7.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.15.3",
 		"@biomejs/biome": "^1.7.2",
-		"@remix-run/node": "^2.8.1",
-		"@remix-run/server-runtime": "^2.8.1",
+		"@react-router/node": "^7.0.0",
 		"@types/bun": "^1.0.12",
 		"@types/debug": "^4.1.12",
 		"@types/jsonwebtoken": "^9.0.6",
 		"consola": "^3.2.3",
 		"jsonwebtoken": "^9.0.2",
 		"msw": "^2.2.13",
-		"remix-auth": "^3.6.0",
+		"remix-auth": "^4.1.0",
 		"typedoc": "^0.25.13",
 		"typedoc-plugin-mdn-links": "^3.1.25",
 		"typescript": "^5.4.5"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,68 +1,39 @@
-import type { SessionStorage } from "@remix-run/server-runtime";
-import { redirect } from "@remix-run/server-runtime";
-import { Issuer, errors, generators } from "openid-client";
+import { Cookie } from "@mjackson/headers";
 import type {
 	Client,
 	ClientMetadata,
 	IssuerMetadata,
 	TokenSet,
 } from "openid-client";
-import type { AuthenticateOptions, StrategyVerifyCallback } from "remix-auth";
-import { Strategy } from "remix-auth";
+import { Issuer, errors, generators } from "openid-client";
+import { redirect } from "react-router";
+import { Strategy } from "remix-auth/strategy";
 
-/**
- * This interface declares what configuration the strategy needs from the
- * developer to correctly work.
- */
-export interface OIDCStrategyOptions extends ClientMetadata, IssuerMetadata {
-	scopes?: string[];
-	audiences?: string[];
-	idTokenCheckParams?: Record<string, unknown>;
-}
-
-/**
- * This interface declares what the developer will receive from the strategy
- * to verify the user identity in their system.
- */
-export interface OIDCStrategyVerifyParams {
-	tokens: TokenSet;
-	request: Request;
-}
-
-export interface OIDCStrategyBaseUser {
-	sub: string;
-	accessToken: string;
-	idToken?: string;
-	refreshToken?: string;
-	expiredAt: number;
-}
-
-const STATE_KEY = "oidc:state";
-const NONCE_KEY = "oidc:nonce";
-const CODE_VERIFIER_KEY = "oidc:code_verifier";
-
-export class OIDCStrategy<User extends OIDCStrategyBaseUser> extends Strategy<
+export class OIDCStrategy<User extends OIDCStrategy.BaseUser> extends Strategy<
 	User,
-	OIDCStrategyVerifyParams
+	OIDCStrategy.VerifyOptions
 > {
 	name = "remix-auth-openid";
-	options: OIDCStrategyOptions;
+	private options: OIDCStrategy.ClientOptions;
 	private client: Client;
+
+	private readonly state_key = "oidc:state";
+	private readonly nonce_key = "oidc:nonce";
+	private readonly code_verifier_key = "oidc:code_verifier";
 
 	private constructor(
 		client: Client,
-		options: OIDCStrategyOptions,
-		verify: StrategyVerifyCallback<User, OIDCStrategyVerifyParams>,
+		options: OIDCStrategy.ClientOptions,
+		verify: Strategy.VerifyFunction<User, OIDCStrategy.VerifyOptions>,
 	) {
 		super(verify);
-
-		this.options = options;
 		this.client = client;
+		this.options = options;
 	}
 
-	public static init = async <User extends OIDCStrategyBaseUser>(
-		options: OIDCStrategyOptions,
-		verify: StrategyVerifyCallback<User, OIDCStrategyVerifyParams>,
+	public static init = async <User extends OIDCStrategy.BaseUser>(
+		options: OIDCStrategy.ClientOptions,
+		verify: Strategy.VerifyFunction<User, OIDCStrategy.VerifyOptions>,
 	) => {
 		// create an openid client
 		let issuer: Issuer;
@@ -76,19 +47,13 @@ export class OIDCStrategy<User extends OIDCStrategyBaseUser> extends Strategy<
 		const client = new issuer.Client({
 			...options,
 		});
-		return new OIDCStrategy<User>(client, options, verify);
+		return new OIDCStrategy(client, options, verify);
 	};
 
-	async authenticate(
-		request: Request,
-		sessionStorage: SessionStorage,
-		options: AuthenticateOptions,
-	): Promise<User> {
+	async authenticate(request: Request): Promise<User> {
 		const url = new URL(request.url);
 
-		const session = await sessionStorage.getSession(
-			request.headers.get("Cookie"),
-		);
+		const session = new Cookie(request.headers.get("Cookie") ?? "");
 
 		// parse callback parameters from IdP
 		const params = this.client.callbackParams(url.toString());
@@ -111,44 +76,32 @@ export class OIDCStrategy<User extends OIDCStrategyBaseUser> extends Strategy<
 			});
 
 			// store requested session bind values into the session
-			session.set(STATE_KEY, state);
-			session.set(NONCE_KEY, nonce);
-			session.set(CODE_VERIFIER_KEY, codeVerifier);
+			session.set(this.state_key, state);
+			session.set(this.nonce_key, nonce);
+			session.set(this.code_verifier_key, codeVerifier);
 
 			throw redirect(authzURL, {
 				headers: {
-					"Set-Cookie": await sessionStorage.commitSession(session),
+					"Set-Cookie": session.toString(),
 				},
 			});
 		}
 
 		// callback from the IdP in the below
-		const state = session.get(STATE_KEY);
-		const nonce = session.get(NONCE_KEY);
-		const verifier = session.get(CODE_VERIFIER_KEY);
+		const state = session.get(this.state_key);
+		const nonce = session.get(this.nonce_key);
+		const verifier = session.get(this.code_verifier_key);
 
 		// exchange code for tokens
 
 		// check if the state is the same as the one we sent
 		if (params.state !== state) {
-			return await this.failure(
-				"Invalid state",
-				request,
-				sessionStorage,
-				options,
-				new ReferenceError("Invalid state"),
-			);
+			throw new ReferenceError("Invalid state");
 		}
 
 		// check if code is present
 		if (!params.code) {
-			return await this.failure(
-				"Invalid code",
-				request,
-				sessionStorage,
-				options,
-				new ReferenceError("Invalid code"),
-			);
+			throw new ReferenceError("Invalid code");
 		}
 
 		// exchange code for tokens
@@ -167,12 +120,7 @@ export class OIDCStrategy<User extends OIDCStrategyBaseUser> extends Strategy<
 			);
 
 			// check caller intended verification
-			const user = await this.verify({
-				tokens: tokens,
-				request: request,
-			});
-
-			return this.success(user, request, sessionStorage, options);
+			return this.verify({ tokens, request });
 		} catch (e) {
 			let message: string;
 
@@ -190,37 +138,20 @@ export class OIDCStrategy<User extends OIDCStrategyBaseUser> extends Strategy<
 				message = "Token exchange failed due to unknown error";
 			}
 
-			return await this.failure(
-				message,
-				request,
-				sessionStorage,
-				options,
-				e as Error,
-			);
+			throw new Error(message);
 		}
 	}
 
-	public async refresh(
-		refreshToken: string,
-		options: Pick<AuthenticateOptions, "failureRedirect">,
-	): Promise<TokenSet | null> {
-		try {
-			const tokens = await this.client.refresh(refreshToken);
-			return tokens;
-		} catch (e) {
-			if (options.failureRedirect) {
-				throw redirect(options.failureRedirect);
-			}
-		}
-		return null;
+	public async refresh(refreshToken: string): Promise<TokenSet> {
+		return await this.client.refresh(refreshToken);
 	}
 
-	public frontChannelLogout(idToken: string) {
-		throw redirect(this.logoutUrl(idToken));
+	public redirectToLogoutUrl(idToken: string): void {
+		throw redirect(this.getLogoutUrl(idToken));
 	}
 
-	public async backChannelLogout(idToken: string) {
-		const url = new URL(this.logoutUrl(idToken));
+	public async postLogoutUrl(idToken: string): Promise<Response> {
+		const url = new URL(this.getLogoutUrl(idToken));
 
 		const body = new URLSearchParams();
 		body.append("id_token_hint", idToken);
@@ -255,10 +186,39 @@ export class OIDCStrategy<User extends OIDCStrategyBaseUser> extends Strategy<
 		return response;
 	}
 
-	private logoutUrl(idToken: string): string {
+	private getLogoutUrl(idToken: string): string {
 		return this.client.endSessionUrl({
 			id_token_hint: idToken,
 			state: generators.state(),
 		});
+	}
+}
+
+export namespace OIDCStrategy {
+	/**
+	 * This interface declares what configuration the strategy needs from the
+	 * developer to correctly work.
+	 */
+	export interface ClientOptions extends ClientMetadata, IssuerMetadata {
+		scopes?: string[];
+		audiences?: string[];
+		idTokenCheckParams?: Record<string, unknown>;
+	}
+
+	/**
+	 * This interface declares what the developer will receive from the strategy
+	 * to verify the user identity in their system.
+	 */
+	export interface VerifyOptions {
+		tokens: TokenSet;
+		request: Request;
+	}
+
+	export interface BaseUser {
+		sub: string;
+		accessToken: string;
+		idToken?: string;
+		refreshToken?: string;
+		expiredAt: number;
 	}
 }

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -42,6 +42,7 @@ describe("OIDC Strategy", () => {
 
 		const redirect = new URL(response.headers.get("Location") ?? "");
 		const session = new Cookie(response.headers.get("set-cookie") ?? "");
+		const params = new URLSearchParams(session.get("oidc:params") ?? "");
 
 		expect(redirect.pathname).toBe("/authorize");
 		expect(redirect.searchParams.get("response_type")).toBe("code");
@@ -51,15 +52,15 @@ describe("OIDC Strategy", () => {
 		);
 		expect(redirect.searchParams.get("state")).toBeDefined();
 		expect(redirect.searchParams.get("state")).toBe(
-			session.get("oidc:state") || "",
+			params.get("oidc:state") || "",
 		);
 		expect(redirect.searchParams.get("nonce")).toBeDefined();
 		expect(redirect.searchParams.get("nonce")).toBe(
-			session.get("oidc:nonce") || "",
+			params.get("oidc:nonce") || "",
 		);
 		expect(redirect.searchParams.get("code_challenge")).toBeDefined();
 		expect(redirect.searchParams.get("code_challenge")).toBe(
-			generators.codeChallenge(session.get("oidc:code_verifier") || ""),
+			generators.codeChallenge(params.get("oidc:code_verifier") || ""),
 		);
 		expect(redirect.searchParams.get("code_challenge_method")).toBe("S256");
 	});
@@ -81,7 +82,10 @@ describe("OIDC Strategy", () => {
 		const stateValue = "123456";
 
 		const session = new Cookie();
-		session.set("oidc:state", stateValue);
+		session.set(
+			"oidc:params",
+			new URLSearchParams({ "oidc:state": stateValue }).toString(),
+		);
 
 		const request = new Request(
 			`https://remix.auth/callback?state=${stateValue}`,
@@ -122,9 +126,14 @@ describe("OIDC Strategy", () => {
 		const stateValue = "dummy-state";
 
 		const session = new Cookie();
-		session.set("oidc:state", stateValue);
-		session.set("oidc:nonce", "dummy-nonce");
-		session.set("oidc:code_verifier", "dummy-code-verifier");
+		session.set(
+			"oidc:params",
+			new URLSearchParams({
+				"oidc:state": stateValue,
+				"oidc:nonce": "dummy-nonce",
+				"oidc:code_verifier": "dummy-code-verifier",
+			}).toString(),
+		);
 
 		const request = new Request(
 			`https://remix.auth/callback?state=${stateValue}&code=123456`,


### PR DESCRIPTION
1. The OIDCStrategy is upgraded to Remix Auth v4
2. state, nonce and code_verifier are stored in cookies by `@mjackson/headers`
3. The name of `frontChannelLogout` and `backchannelLogout` are changed to `redirectToLogoutUri` and `postLogoutUri` due to avoid confusing OpenID Connect Front Channel and Back Channel Logout Spec. 

fix for https://github.com/manaty226/remix-auth-openid/issues/2